### PR TITLE
Fixed bug when computing expressions in item lookup

### DIFF
--- a/source/test.rs
+++ b/source/test.rs
@@ -1,33 +1,7 @@
-fn receive(channel: 'return) -> {
-    return [true, channel]
-}
-
-fn check_msg(obj) {
-    if obj[0] {
-        println(obj[1].msg)
-    } else {
-        println("<connection closed>")
-    }
-}
-
-fn close(obj) {
-    obj[0] = false
-    obj[1] := []
-}
-
 fn main() {
-    a := {msg: "none"}
-
-    b := receive(a)
-    c := {send: a}
-
-    c.send.msg = "hi!"
-
-    check_msg(b) // prints "hi!"
-
-    close(b)
-
-    c.send.msg = "are you there?"
-
-    check_msg(b) // prints "<connection closed>"
+    x := [0, 1, 2, 3, 4]
+    for i := 0; i < len(x); i += 1 {
+        x[i] += 1
+    }
+    println(x)
 }


### PR DESCRIPTION
Use raw pointer to variable instead of splitting the stack. The
splitting caused problems in `x[i]` when `i` was declared after `x`.